### PR TITLE
Slobber version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gaze": "^0.5.1",
     "jade": "^1.11.0",
     "node-notifier": "^4.2.3",
-    "slobber": "0.2.0",
+    "slobber": "0.3.0",
     "socket.io": "^1.3.6"
   }
 }


### PR DESCRIPTION
Assuming slobber 0.3.0 is available. Should have been on 0.2.0 at least.
